### PR TITLE
Small DX improvements for entityTransformation

### DIFF
--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -28,7 +28,6 @@ const entityTransformation = async (entity: Entity, api: ApiVersion | API) => {
   //   },
   // };
   return entity;
-  return entity;
 };
 
 export const catalogGlooPlatformPortalBackendProvider = createBackendModule({

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -14,20 +14,19 @@ import {
 } from '@backstage/backend-plugin-api';
 import { Entity } from '@backstage/catalog-model';
 import { catalogProcessingExtensionPoint } from '@backstage/plugin-catalog-node/alpha';
-import { GlooPlatformPortalProvider } from '@solo.io/platform-portal-backstage-plugin-backend';
+import { API, ApiVersion, GlooPlatformPortalProvider } from '@solo.io/platform-portal-backstage-plugin-backend';
 
 // Entities can be transformed using this function.
 // The entity that is returned here will be added to the catalog.
-const entityTransformation = async (entity: Entity, api: any) => {
+const entityTransformation = async (entity: Entity, api: ApiVersion | API) => {
   // The following commented out lines would add an "example-" prefix to your Entities.
-  // entity = {
+  // return {
   //   ...entity,
   //   metadata: {
   //     ...entity.metadata,
   //     title: 'example-' + (entity?.metadata?.title ?? ''),
   //   },
   // };
-  return entity;
 };
 
 export const catalogGlooPlatformPortalBackendProvider = createBackendModule({

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -27,6 +27,7 @@ const entityTransformation = async (entity: Entity, api: ApiVersion | API) => {
   //     title: 'example-' + (entity?.metadata?.title ?? ''),
   //   },
   // };
+  return entity;
 };
 
 export const catalogGlooPlatformPortalBackendProvider = createBackendModule({

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -28,6 +28,7 @@ const entityTransformation = async (entity: Entity, api: ApiVersion | API) => {
   //   },
   // };
   return entity;
+  return entity;
 };
 
 export const catalogGlooPlatformPortalBackendProvider = createBackendModule({

--- a/plugins/platform-portal-backstage-plugin-backend/README.md
+++ b/plugins/platform-portal-backstage-plugin-backend/README.md
@@ -33,21 +33,20 @@ import {
 } from '@backstage/backend-plugin-api';
 import { Entity } from '@backstage/catalog-model';
 import { catalogProcessingExtensionPoint } from '@backstage/plugin-catalog-node/alpha';
-import { GlooPlatformPortalProvider } from '@solo.io/platform-portal-backstage-plugin-backend';
+import { API, ApiVersion, GlooPlatformPortalProvider } from '@solo.io/platform-portal-backstage-plugin-backend';
 
 // -> 2. Optionally define an `entityTransformation`.
 // Entities can be transformed using this function.
 // The entity that is returned here will be added to the catalog.
-const entityTransformation = async (entity: Entity, api: any) => {
+const entityTransformation = async (entity: Entity, api: ApiVersion | API) => {
   // The following commented out lines would add an "example-" prefix to your Entities.
-  // entity = {
+  // return {
   //   ...entity,
   //   metadata: {
   //     ...entity.metadata,
   //     title: 'example-' + (entity?.metadata?.title ?? ''),
   //   },
   // };
-  return entity;
 };
 
 // -> 3. Create the provider for our plugin.

--- a/plugins/platform-portal-backstage-plugin-backend/README.md
+++ b/plugins/platform-portal-backstage-plugin-backend/README.md
@@ -47,6 +47,7 @@ const entityTransformation = async (entity: Entity, api: ApiVersion | API) => {
   //     title: 'example-' + (entity?.metadata?.title ?? ''),
   //   },
   // };
+  return entity;
 };
 
 // -> 3. Create the provider for our plugin.

--- a/plugins/platform-portal-backstage-plugin-backend/src/index.ts
+++ b/plugins/platform-portal-backstage-plugin-backend/src/index.ts
@@ -1,1 +1,2 @@
 export * from './provider/GlooPlatformPortalProvider';
+export type { API, ApiVersion } from './provider/api-types';


### PR DESCRIPTION
Hi @Charlesthebird , thank you for helping with entityTransformation, I tested the functionality and added here some very small suggestions/improvements. Please let me know what you think:)

- export API and ApiVersion types to be reachable to client application when used in entityTransformation  such that consumer applications wouldn' need to use `any` to deactivate type checking
- update README and index.ts example with examples that has type checking and don't use any
- update example to not use param reassigning - it might lead to unwanted side-effects inside the library due to reference change and is usually not a good practice (https://eslint.org/docs/latest/rules/no-param-reassign)

